### PR TITLE
Avoid error while loading JSON with control characters

### DIFF
--- a/server.py
+++ b/server.py
@@ -41,10 +41,10 @@ class Jarvis():
                 config_file.write (value.encode('utf-8')+'\n')
     
     def say (self, phrase):
-        return json.loads(self._exec (["-s", phrase]))
+        return json.loads(self._exec (["-s", phrase]), strict=False)
     
     def handle_order (self, order):
-        return json.loads(self._exec (["-x", order]))
+        return json.loads(self._exec (["-x", order]), strict=False)
     
     def listen (self):
         return json.loads(self._exec (["-l"]))


### PR DESCRIPTION
See https://docs.python.org/2/library/json.html §18.2.2
`If strict is false (True is the default), then control characters will be allowed inside strings. Control characters in this context are those with character codes in the 0–31 range, including '\t' (tab), '\n', '\r' and '\0'`

It as been detected [here](https://github.com/Oliv4945/jarvis-android-app/issues/9#issuecomment-297759951).