### PR TITLE
Change the startup command from python to python2

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -10,5 +10,5 @@
 jv_pg_api_start () {
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     jv_debug "Starting RestAPI server on http://$jv_ip:$jv_pg_api_port"
-    python $DIR/server.py --port $jv_pg_api_port --key "$jv_pg_api_key" & # 2>&1 | jv_add_timestamps >>$jv_dir/jarvis.log &
+    python2 $DIR/server.py --port $jv_pg_api_port --key "$jv_pg_api_key" & # 2>&1 | jv_add_timestamps >>$jv_dir/jarvis.log &
 }

--- a/server.py
+++ b/server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 import argparse # manage program arguments
 import json # read input json


### PR DESCRIPTION
The `python` command isn't always symlinked on python2 binary on every distribution, for example ArchLinux use Python 3 as a default version for Python so renaming the command from `python` to `python2` is the best way to make this program working on every Linux distribution.

------------------------------
La commande `python` n'est pas toujours liée au binaire `python2` sur chaque distribution, par exemple ArchLinux utilise Python 3 comme version de Python par défaut donc renommer la commande `python` vers `python2` est le meilleur moyen pour que ce programme fonctionne sur toutes les versions distributions Linux.